### PR TITLE
Skyplot xlabel position

### DIFF
--- a/simulation/simultarget.py
+++ b/simulation/simultarget.py
@@ -196,7 +196,8 @@ class TransientGenerator( BaseObject ):
             ax_default = dict(fig=None, figsize=(12, 6), 
                               rect=[0.1, 0.1, 0.8, 0.8], 
                               projection='mollweide',
-                              xlabelpad=None)
+                              xlabelpad=None,
+                              xlabelmode='show')
             if cscale is not None:
                 ax_default['figsize'] = (12,8)
                 
@@ -245,7 +246,8 @@ class TransientGenerator( BaseObject ):
             ax_default = dict(fig=None, figsize=(12, 6),
                               rect=[0.1, 0.1, 0.8, 0.8],
                               projection='mollweide',
-                              xlabelpad=None)
+                              xlabelpad=None,
+                              xlabelmode='hist')
             ax_kw, kwargs = kwargs_extract(ax_default, **kwargs)
             fig, ax = ax_skyplot(**ax_kw)
         elif ("MollweideTransform" not in dir(ax) and

--- a/simulation/simultarget.py
+++ b/simulation/simultarget.py
@@ -194,8 +194,9 @@ class TransientGenerator( BaseObject ):
         # - Axis definition
         if ax is None:
             ax_default = dict(fig=None, figsize=(12, 6), 
-                                   rect=[0.1, 0.1, 0.8, 0.8], 
-                                   projection='mollweide')
+                              rect=[0.1, 0.1, 0.8, 0.8], 
+                              projection='mollweide',
+                              xlabelpad=None)
             if cscale is not None:
                 ax_default['figsize'] = (12,8)
                 
@@ -243,7 +244,8 @@ class TransientGenerator( BaseObject ):
         if ax is None:
             ax_default = dict(fig=None, figsize=(12, 6),
                               rect=[0.1, 0.1, 0.8, 0.8],
-                              projection='mollweide')
+                              projection='mollweide',
+                              xlabelpad=None)
             ax_kw, kwargs = kwargs_extract(ax_default, **kwargs)
             fig, ax = ax_skyplot(**ax_kw)
         elif ("MollweideTransform" not in dir(ax) and

--- a/utils/plot/skyplot.py
+++ b/utils/plot/skyplot.py
@@ -19,7 +19,7 @@ __all__ = ["ax_skyplot"]
 # = Axis setup                 = #
 # ============================== #
 def ax_skyplot(fig=None, figsize=(12, 6), rect=[0.1, 0.1, 0.8, 0.8], 
-               projection='mollweide', xlabelpad=None): 
+               projection='mollweide', xlabelpad=None, xlabelmode='hist'): 
     """
     Initialize axis for skyplot and make grid and labels nicer.
     [Fill in kwargs]
@@ -28,13 +28,21 @@ def ax_skyplot(fig=None, figsize=(12, 6), rect=[0.1, 0.1, 0.8, 0.8],
     import matplotlib as m
     mv = m.__version__.split('.')
     if int(mv[0]) < 2 and int(mv[1]) < 5:
+        xlabeladjust = {'show': 180, 
+                        'hist': 165}
+        
+        if xlabelmode not in xlabeladjust.keys():
+            raise ValueError('Unknown xlabelmode. Know values: %2'%
+                             (', '.join(xlabeladjust.keys())))
+            
         warnings.warn('You are using matplotlib version < 1.5.0. '+
                       'The padding of the xlabel has been adjusted. '+
                       'You can use the option "xlabelpad" to adjust.')
+
         if xlabelpad is None:
-            xlabelpad = 165
+            xlabelpad = xlabeladjust[xlabelmode]
         else:
-            xlabelpad += 165
+            xlabelpad += xlabeladjust[xlabelmode]
 
     allowed_proj = ['mollweide', 'hammer']
 

--- a/utils/plot/skyplot.py
+++ b/utils/plot/skyplot.py
@@ -9,6 +9,7 @@ longitude direction to get a celestial plot.
 
 import numpy as np
 import matplotlib.pyplot as mpl
+import warnings
 
 _d2r = np.pi / 180 
 
@@ -18,11 +19,23 @@ __all__ = ["ax_skyplot"]
 # = Axis setup                 = #
 # ============================== #
 def ax_skyplot(fig=None, figsize=(12, 6), rect=[0.1, 0.1, 0.8, 0.8], 
-               projection='mollweide'): 
+               projection='mollweide', xlabelpad=None): 
     """
     Initialize axis for skyplot and make grid and labels nicer.
     [Fill in kwargs]
     """
+    # Work around to get correct xlabel position in older matplotlib
+    import matplotlib as m
+    mv = m.__version__.split('.')
+    if int(mv[0]) < 2 and int(mv[1]) < 5:
+        warnings.warn('You are using matplotlib version < 1.5.0. '+
+                      'The padding of the xlabel has been adjusted. '+
+                      'You can use the option "xlabelpad" to adjust.')
+        if xlabelpad is None:
+            xlabelpad = 165
+        else:
+            xlabelpad += 165
+
     allowed_proj = ['mollweide', 'hammer']
 
     if fig is None:
@@ -37,7 +50,8 @@ def ax_skyplot(fig=None, figsize=(12, 6), rect=[0.1, 0.1, 0.8, 0.8],
     xlabels = [u'%i\xb0'%ra for ra in range(150,-1,-30) + range(330,209,-30)]
     ax.set_xticklabels(xlabels)
 
-    ax.set_xlabel(r"$\mathrm{RA\ [deg]}$", fontsize="x-large")
+    ax.set_xlabel(r"$\mathrm{RA\ [deg]}$", fontsize="x-large", 
+                  labelpad=xlabelpad)
     ax.set_ylabel(r"$\mathrm{Dec\ [deg]}$", fontsize="x-large")
 
     return fig, ax


### PR DESCRIPTION
This implements a workaround to get a good xlabel position in skyplots for matplotib version < 1.5.0. Only works if the figure is of default size. Otherwise adjustment is required.
Fixes #6.
