### PR TITLE
surveyfields progress_bar added

### DIFF
--- a/astrobject/utils/plot/skybins.py
+++ b/astrobject/utils/plot/skybins.py
@@ -17,6 +17,8 @@ import warnings
 import numpy as np
 from copy import copy
 
+from astropy.utils.console import ProgressBar
+
 from ...__init__ import BaseObject
 #import astrobject.astrobject import baseobject as b
 from .skyplot import rot_xz_sph
@@ -465,12 +467,20 @@ class SurveyFieldBins( BaseBins ):
         return np.array([np.sum(f.coord_in_field(ra, dec)) 
                          for f in self.fields])
 
-    def coord2field(self, ra, dec):
+    def coord2field(self, ra, dec, progress_bar=False):
         """
         Return the lists of fields in which a list of coordinates fall.
         Keep in mind that the fields will likely overlap.
         """
-        bo = [f.coord_in_field(ra, dec) for f in self.fields]
+        bo = []
+        gen = self.fields
+
+        if progress_bar:
+            print "Determining field IDs for all objects"
+            gen = ProgressBar(gen)
+
+        for f in gen:
+            bo.append(f.coord_in_field(ra, dec))
 
         # Handle the single coordinate case first
         if type(bo[0]) is np.bool_:


### PR DESCRIPTION
Added the option to show a progress bar when the surveyfields binner determines which fields the transient are located in. Useful when generating a large set of lcs because this step can take a minute or two.
