### PR TITLE
INFO lbda now consistent with sncosmo wave_eff 

### DIFF
--- a/astrobject/instruments/galex.py
+++ b/astrobject/instruments/galex.py
@@ -14,8 +14,10 @@ from ..photometry       import get_photopoint
 from ..utils.decorators import _autogen_docstring_inheritance
 from ..utils.tools      import kwargs_update
 
-GALEX_INFO= {"fuv":{"lbda":1516,"ABmag0":18.82},
-             "nuv":{"lbda":2267,"ABmag0":20.08},
+# filter transmissions from FSPS allfilters.dat
+# effective wavelength from sncosmo
+GALEX_INFO= {"fuv":{"lbda":1538.620702,"ABmag0":18.82},
+             "nuv":{"lbda":2315.663104,"ABmag0":20.08},
              "bands":["fuv","nuv"],
              "telescope":{
                  "lon": None,

--- a/astrobject/instruments/hst.py
+++ b/astrobject/instruments/hst.py
@@ -14,17 +14,19 @@ _FWHM_WFC3 = Table(data=[[2000,3000,4000,5000,6000,7000,8000,9000,10000,11000],
                          [0.083,0.075,0.070,0.067,0.067,0.070,0.074,0.078,0.084,0.089]],
                    names=["wavelength","FWHM"])
 
+# F225W filter from David Rubin: Averaged chip 1 and chip 2
+# transmission from SYNPHOT (STSci software)
 HST_INFO = {
     "telescope":{
                  "lon":np.NaN,
                  "lat":np.NaN},
     # Windhorst et al 2010
-    "f225w":{"fwhm":0.092,
-             "mab0":24.06, # abmag @ e-/s
+    "f225w":{"lbda":2372.069991, "fwhm":0.092,
+             "ABmag0":24.06, # abmag @ e-/s
              "skybkgd":25.46 # mag per arcsec 2
              },
-    "f275w":{"fwhm":0.087,
-             "mab0":24.14,
+    "f275w":{"lbda":2708.529114, "fwhm":0.087,
+             "ABmag0":24.14,
              "skybkgd":25.64 # mag per arcsec 2
             }
         

--- a/astrobject/instruments/panstarrs.py
+++ b/astrobject/instruments/panstarrs.py
@@ -16,10 +16,18 @@ from ..photometry       import get_photopoint
 from ..utils.decorators import _autogen_docstring_inheritance
 from ..utils.tools      import kwargs_update
 
-PANSTARRS_INFO= {"bands":["ps1.g","ps1.r","ps1.i","ps1.z","ps1.z"],
+# filter transmissions from Tonry et al. (2012):
+# http://iopscience.iop.org/0004-637X/750/2/99/suppdata/apj425122t3_mrt.txt
+# effective wavelengths from sncosmo
+PANSTARRS_INFO= {"ps1.g":{"lbda":4866.457871,"ABmag0":25.0},
+                 "ps1.r":{"lbda":6214.623038,"ABmag0":25.0},
+                 "ps1.g":{"lbda":7544.570357,"ABmag0":25.0},
+                 "ps1.g":{"lbda":8679.482571,"ABmag0":25.0},
+                 "ps1.g":{"lbda":9633.284241,"ABmag0":25.0},
+                 "bands":["ps1.g","ps1.r","ps1.i","ps1.z","ps1.y"],
                  "telescope":{
-                     "lon": None,
-                     "lat": None}}
+                     "lon": -156.2571, 
+                     "lat": 20.7083}}
 """
 Info from Magnier 2016
 

--- a/astrobject/instruments/sdss.py
+++ b/astrobject/instruments/sdss.py
@@ -7,11 +7,12 @@ from ..utils.decorators import _autogen_docstring_inheritance
 
 __all__ = ["sdss","SDSS_INFO"]
 
-SDSS_INFO = {"u":{"lbda":3551,"ABmag0":22.46},
-             "g":{"lbda":4686,"ABmag0":22.50},
-             "r":{"lbda":6166,"ABmag0":22.50},
-             "i":{"lbda":7480,"ABmag0":22.50},
-             "z":{"lbda":8932,"ABmag0":22.52},
+# filter transmission & effective wavelength from sncosmo
+SDSS_INFO = {"u":{"lbda":3594.325367,"ABmag0":22.46},
+             "g":{"lbda":4717.599777,"ABmag0":22.50},
+             "r":{"lbda":6186.799970,"ABmag0":22.50},
+             "i":{"lbda":7506.238080,"ABmag0":22.50},
+             "z":{"lbda":8918.301484,"ABmag0":22.52},
             "bands":["u","g","r","i","z"],
              "telescope":{
                  "lon": 32.780,

--- a/astrobject/instruments/twomass.py
+++ b/astrobject/instruments/twomass.py
@@ -8,9 +8,11 @@ from ..utils.tools import kwargs_update
 
 __all__  = ["twomass", "TWOMASS_INFO"]
 
-TWOMASS_INFO= {"2massJ":{"lbda":12350.0},
-               "2massH":{"lbda":16620.0},
-               "2massKs":{"lbda":21590.0},
+# filter transmission from FSPS allfilters.dat
+# effective wavelength from sncosmo
+TWOMASS_INFO= {"2massJ":{"lbda":12408.375977},
+               "2massH":{"lbda":16513.664599},
+               "2massKs":{"lbda":21655.392611},
                "bands":["2massJ","2massH","2massKs"],
                "telescope":{
                    "lon": None,
@@ -115,3 +117,11 @@ class TWOMASS( Instrument ):
         """ The gain of the instrument """
         return None
     
+    # =========================== #
+    # = Internal Tools          = #
+    # =========================== #
+    # -----------------
+    # - Background hacking
+
+    def _get_default_background_(self,*args,**kwargs):
+        return np.zeros(np.shape(self.rawdata))

--- a/astrobject/instruments/wise.py
+++ b/astrobject/instruments/wise.py
@@ -11,11 +11,13 @@ __all__  = ["wise", "WISE_INFO"]
 """ 
 unWISE images have Vega ZP=22.5. Need to add AB offsets from
 http://wise2.ipac.caltech.edu/docs/release/allsky/expsup/sec4_4h.html#conv2ab
+Filter transmissions from FSPS allfilters.dat
+Effective wavelength from sncosmo
 """
-WISE_INFO= {"wisew1":{"lbda":33680.0,"ABmag0":22.5+2.699},
-            "wisew2":{"lbda":46180.0,"ABmag0":22.5+3.339},
-            "wisew3":{"lbda":120820.0,"ABmag0":22.5+5.174},
-            "wisew4":{"lbda":221940.0,"ABmag0":22.5+6.620},
+WISE_INFO= {"wisew1":{"lbda":33791.912981,"ABmag0":22.5+2.699},
+            "wisew2":{"lbda":46292.961143,"ABmag0":22.5+3.339},
+            "wisew3":{"lbda":123321.610431,"ABmag0":22.5+5.174},
+            "wisew4":{"lbda":222532.734640,"ABmag0":22.5+6.620},
             "bands":["wisew1","wisew2","wisew3","wisew4"],
             "telescope":{
                  "lon": None,


### PR DESCRIPTION
for galex, hst, panstarrs, sdss, twomass, wise. 
I also explicitly set the twomass background to np.zeros like sdss and made some other minor fixes in the instrument files.